### PR TITLE
feat: 初回ログイン時のデータ取得をキャッシュする機能を追加

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8,6 +8,7 @@ version = "0.1.0"
 dependencies = [
  "base64 0.21.7",
  "chacha20poly1305",
+ "chrono",
  "dirs",
  "eframe",
  "egui",
@@ -235,6 +236,21 @@ name = "android-properties"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
+
+[[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
+name = "android_system_properties"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "arboard"
@@ -829,6 +845,21 @@ dependencies = [
  "cipher",
  "poly1305",
  "zeroize",
+]
+
+[[package]]
+name = "chrono"
+version = "0.4.41"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "serde",
+ "wasm-bindgen",
+ "windows-link",
 ]
 
 [[package]]
@@ -2214,6 +2245,30 @@ dependencies = [
  "tokio",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.63"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0c919e5debc312ad217002b8048a17b7d83f80703865bbfcfebb0458b0b27d8"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,4 +30,5 @@ usvg = "0.45"
 fluent = "0.16"
 unic-langid = "0.9"
 intl-memoizer = "0.5"
+chrono = { version = "0.4", features = ["serde"] }
 


### PR DESCRIPTION
初回ログイン時に取得するNIP-02フォローリスト、NIP-65リレーリスト、自身のNIP-01プロフィールをローカルファイルにキャッシュする機能を追加しました。

これにより、2回目以降のログインが高速化され、ユーザーエクスペリエンスが向上します。

主な変更点:
- `Cargo.toml` に `chrono` を追加し、タイムスタンプを扱えるようにした
- アプリケーション起動時に `cache` ディレクトリを作成する処理を追加
- キャッシュデータを保存するための汎用的な `Cache<T>` 構造体を定義
- `ui.rs` の `fetch_initial_data` をリファクタリングし、キャッシュの読み書き処理を実装