### PR TITLE
refactor: Parallelize relay connection logic

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ dependencies = [
  "env_logger",
  "epaint",
  "fluent",
+ "futures",
  "hex",
  "hmac",
  "intl-memoizer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,6 @@ fluent = "0.16"
 unic-langid = "0.9"
 intl-memoizer = "0.5"
 chrono = { version = "0.4", features = ["serde"] }
+futures = "0.3"
 
 


### PR DESCRIPTION
The `connect_to_relays_with_nip65` function was previously adding relays sequentially, awaiting each `add_relay` call one by one. This created a bottleneck, especially when connecting to a large number of relays.

This change refactors the relay addition logic to be fully parallel. It collects all `add_relay` futures into a list and then executes them concurrently using `futures::future::join_all`. This significantly speeds up the initial connection process.

The `futures` crate was added as a new dependency to support this change.