### PR TITLE
feat: Add support for NIP-30 custom emojis

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,6 +29,7 @@ dependencies = [
  "nostr-types",
  "pbkdf2",
  "rand 0.8.5",
+ "regex",
  "resvg",
  "rpassword 2.1.0",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+regex = "1"
 nostr-lmdb = "0.39.0"
 heed = "0.20"
 nostr = "0.30"

--- a/src/main.rs
+++ b/src/main.rs
@@ -93,6 +93,8 @@ pub struct TimelinePost {
     pub author_metadata: ProfileMetadata,
     pub content: String,
     pub created_at: nostr::Timestamp,
+    #[serde(default)]
+    pub emojis: HashMap<String, String>, // shortcode -> url
 }
 
 // アプリケーションの内部状態を保持する構造体


### PR DESCRIPTION
This commit implements support for displaying custom emojis in the timeline, as specified by NIP-30.

- Adds the `regex` crate for parsing emoji shortcodes from post content.
- The `TimelinePost` struct in `src/main.rs` is updated to include a `HashMap` that stores the mapping of emoji shortcodes to their corresponding image URLs.
- The event fetching logic in `src/ui.rs` is modified to parse `Tag::Emoji` from Nostr events and populate the new `emojis` field in `TimelinePost`.
- A new function, `render_post_content`, is introduced in `src/ui.rs`. This function uses a regular expression to find shortcodes (e.g., `:smile:`) in the text. If a valid emoji is found, it renders the image using the existing image cache mechanism. If not, it renders the shortcode as plain text.
- The timeline UI is updated to use this new rendering function, replacing the simple text label.