### PR TITLE
refactor(ui): Move post button to side panel and modernize style

### DIFF
--- a/src/ui.rs
+++ b/src/ui.rs
@@ -71,6 +71,20 @@ impl eframe::App for NostrStatusApp {
                         );
                     }
                 });
+
+                if app_data.is_logged_in {
+                    ui.add_space(20.0);
+
+                    // --- 投稿ボタン ---
+                    let post_button_text = egui::RichText::new("投稿する").size(14.0).strong();
+                    let button = egui::Button::new(post_button_text)
+                        .min_size(egui::vec2(ui.available_width(), 40.0))
+                        .corner_radius(egui::CornerRadius::from(8.0));
+
+                    if ui.add(button).clicked() {
+                        app_data.show_post_dialog = true;
+                    }
+                }
             });
 
         egui::CentralPanel::default()

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -440,12 +440,4 @@ pub fn draw_home_view(
         }
     });
 
-    egui::Area::new("fab_area".into())
-        .order(egui::Order::Foreground)
-        .anchor(egui::Align2::RIGHT_BOTTOM, egui::vec2(-20.0, -20.0))
-        .show(ctx, |ui| {
-            if ui.button(egui::RichText::new("➕").size(24.0)).clicked() {
-                app_data.show_post_dialog = true;
-            }
-        });
 }


### PR DESCRIPTION
- Removes the floating action button (FAB) for posting from the home view.
- Adds a new, full-width 'Post' button to the side panel, displayed only when logged in.
- The new button is styled to be more modern and prominent.
- The core functionality of opening the post dialog remains unchanged.
- Fixes a deprecated use of `egui::Rounding` to `egui::CornerRadius`.