### PR TITLE
feat: Add Wallet tab for NWC configuration

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -163,6 +163,7 @@ impl NostrStatusApp {
             LmdbCache::new(Path::new(DB_PATH)).expect("Failed to initialize LMDB cache");
 
         let app_data_internal = NostrStatusAppInternal {
+            nwc_uri_input: String::new(),
             cache_db: lmdb_cache,
             is_logged_in: false,
             status_message_input: String::new(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -93,6 +93,7 @@ pub struct TimelinePost {
 pub enum AppTab {
     Home,
     Relays,
+    Wallet,
     Profile,
 }
 
@@ -140,6 +141,7 @@ impl AppTheme {
 }
 
 pub struct NostrStatusAppInternal {
+    pub nwc_uri_input: String,
     pub cache_db: LmdbCache,
     pub is_logged_in: bool,
     pub status_message_input: String,

--- a/src/ui.rs
+++ b/src/ui.rs
@@ -2,6 +2,7 @@ pub mod login_view;
 pub mod home_view;
 pub mod relays_view;
 pub mod profile_view;
+pub mod wallet_view;
 pub mod image_cache;
 
 use eframe::egui::{self, Margin};
@@ -18,6 +19,7 @@ impl eframe::App for NostrStatusApp {
 
         let home_tab_text = "ホーム";
         let relays_tab_text = "リレー";
+        let wallet_tab_text = "ウォレット";
         let profile_tab_text = "プロフィール";
 
         // app_data_arc をクローンして非同期タスクに渡す
@@ -66,6 +68,11 @@ impl eframe::App for NostrStatusApp {
                         );
                         ui.selectable_value(
                             &mut app_data.current_tab,
+                            AppTab::Wallet,
+                            wallet_tab_text,
+                        );
+                        ui.selectable_value(
+                            &mut app_data.current_tab,
                             AppTab::Profile,
                             profile_tab_text,
                         );
@@ -103,6 +110,9 @@ impl eframe::App for NostrStatusApp {
                         },
                         AppTab::Relays => {
                            relays_view::draw_relays_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);
+                        },
+                        AppTab::Wallet => {
+                            wallet_view::draw_wallet_view(ui, &mut app_data, app_data_arc_clone, runtime_handle);
                         },
                         AppTab::Profile => {
                             profile_view::draw_profile_view(ui, ctx, &mut app_data, app_data_arc_clone, runtime_handle);

--- a/src/ui/wallet_view.rs
+++ b/src/ui/wallet_view.rs
@@ -1,0 +1,28 @@
+use eframe::egui;
+use std::sync::{Arc, Mutex};
+use tokio::runtime::Handle;
+
+use crate::types::NostrStatusAppInternal;
+
+pub fn draw_wallet_view(
+    ui: &mut egui::Ui,
+    app_data: &mut NostrStatusAppInternal,
+    _app_data_arc: Arc<Mutex<NostrStatusAppInternal>>,
+    _runtime_handle: Handle,
+) {
+    ui.heading("Wallet");
+    ui.add_space(10.0);
+
+    ui.label("Nostr Wallet Connect (NIP-47)");
+    ui.add_space(5.0);
+
+    ui.horizontal(|ui| {
+        ui.label("NWC URI:");
+        ui.text_edit_singleline(&mut app_data.nwc_uri_input);
+    });
+
+    if ui.button("Save").clicked() {
+        // Here you would handle saving the NWC URI
+        println!("Save button clicked. NWC URI: {}", app_data.nwc_uri_input);
+    }
+}


### PR DESCRIPTION
Adds a new "Wallet" tab to the side panel, positioned between the "Relays" and "Profile" tabs.

This new tab provides a user interface for configuring Nostr Wallet Connect (NIP-47). It includes an input field for the NWC URI and a "Save" button.

The necessary application state and UI logic have been added to support this new view.