### PR TITLE
Refactor: ZAPステータスメッセージとホバーテキストを削除

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,6 @@ impl NostrStatusApp {
             show_zap_dialog: false,
             zap_amount_input: String::new(),
             zap_target_post: None,
-            zap_status_message: None,
         };
         let data = Arc::new(Mutex::new(app_data_internal));
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,5 +188,4 @@ pub struct NostrStatusAppInternal {
     pub show_zap_dialog: bool,
     pub zap_amount_input: String,
     pub zap_target_post: Option<TimelinePost>,
-    pub zap_status_message: Option<String>,
 }

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -128,22 +128,6 @@ pub fn draw_home_view(
     let fetch_latest_button_text = "最新の投稿を取得";
     let no_timeline_message_text = "タイムラインに投稿はまだありません。";
 
-    // --- ZAP Status Message ---
-    let mut clear_status_message = false;
-    if let Some(status) = &app_data.zap_status_message {
-        let status_clone = status.clone();
-        ui.horizontal(|ui|{
-            ui.label(status_clone);
-            if ui.button("x").clicked() {
-                clear_status_message = true;
-            }
-        });
-    }
-    if clear_status_message {
-        app_data.zap_status_message = None;
-    }
-
-
     let card_frame = egui::Frame {
         inner_margin: egui::Margin::same(12),
         corner_radius: 8.0.into(),
@@ -200,7 +184,6 @@ pub fn draw_home_view(
                                         runtime_handle.spawn(async move {
                                             {
                                                 let mut data = app_data_clone.lock().unwrap();
-                                                data.zap_status_message = Some("ZAPを送信中...".to_string());
                                                 data.should_repaint = true;
                                             } // Lock is dropped here
 
@@ -217,10 +200,10 @@ pub fn draw_home_view(
                                             let mut data = app_data_clone.lock().unwrap();
                                             match result {
                                                 Ok(_) => {
-                                                    data.zap_status_message = Some("ZAPリクエストを送信しました。ウォレットの確認を待っています...".to_string());
+                                                    // ZAPリクエストを送信しました。ウォレットの確認を待っています...
                                                 }
                                                 Err(e) => {
-                                                    data.zap_status_message = Some(format!("ZAPエラー: {}", e));
+                                                    eprintln!("ZAPエラー: {}", e);
                                                 }
                                             }
                                             data.should_repaint = true;
@@ -229,10 +212,10 @@ pub fn draw_home_view(
                                         close_dialog = true;
 
                                     } else {
-                                        app_data.zap_status_message = Some("無効な金額です".to_string());
+                                        eprintln!("無効な金額です");
                                     }
                                 } else {
-                                    app_data.zap_status_message = Some("ZAPにはNWCの接続が必要です".to_string());
+                                    eprintln!("ZAPにはNWCの接続が必要です");
                                 }
                             }
                         });
@@ -692,7 +675,7 @@ pub fn draw_home_view(
                                     if post.author_pubkey != my_keys.public_key() {
                                         // ZAP button
                                         if !post.author_metadata.lud16.is_empty() {
-                                            if ui.button("⚡").on_hover_text("ZAPを送る").clicked() {
+                                            if ui.button("⚡").clicked() {
                                                 app_data.zap_target_post = Some(post.clone());
                                                 app_data.show_zap_dialog = true;
                                                 app_data.zap_amount_input = "21".to_string(); // Default amount

--- a/src/ui/wallet_view.rs
+++ b/src/ui/wallet_view.rs
@@ -190,7 +190,7 @@ async fn listen_for_nwc_responses(
                                         app_data.nwc_error = None;
                                     },
                                     nostr::nips::nip47::ResponseResult::PayInvoice(_pay_invoice_res) => {
-                                        app_data.zap_status_message = Some("ZAP成功！".to_string());
+                                        println!("ZAP成功！");
                                         // Optionally, you could use the preimage from pay_invoice_res for something.
                                     },
                                     _ => {
@@ -198,12 +198,7 @@ async fn listen_for_nwc_responses(
                                     }
                                 }
                             } else if let Some(error) = decrypted_response.error {
-                                // Check if this error is related to a ZAP attempt
-                                if app_data.zap_status_message.is_some() {
-                                    app_data.zap_status_message = Some(format!("ZAP失敗: {}", error.message));
-                                } else {
-                                    app_data.nwc_error = Some(format!("NWCエラー: {}", error.message));
-                                }
+                                app_data.nwc_error = Some(format!("NWCエラー: {}", error.message));
                             }
                         }
                     }


### PR DESCRIPTION
ZAP操作時に表示されていたステータスメッセージ（送信中、成功、エラー）を削除しました。
また、ZAPボタン（⚡）をホバーした際に表示されていた「ZAPを送る」というツールチップも削除しました。

これらの変更は、UIをシンプルにし、ユーザー体験を向上させることを目的としています。
関連する状態管理とUIコードをクリーンアップしました。