### PR TITLE
feat: NIP-06（ニーモニック）関連の機能を削除

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -208,7 +208,6 @@ impl NostrStatusApp {
             show_zap_dialog: false,
             zap_amount_input: String::new(),
             zap_target_post: None,
-            generated_mnemonic: None,
         };
         let data = Arc::new(Mutex::new(app_data_internal));
 

--- a/src/types.rs
+++ b/src/types.rs
@@ -188,5 +188,4 @@ pub struct NostrStatusAppInternal {
     pub show_zap_dialog: bool,
     pub zap_amount_input: String,
     pub zap_target_post: Option<TimelinePost>,
-    pub generated_mnemonic: Option<String>,
 }

--- a/src/ui/login_view.rs
+++ b/src/ui/login_view.rs
@@ -4,10 +4,7 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 use std::collections::HashSet;
 use std::time::Duration;
-use rand::RngCore;
-
-use bip39::{Mnemonic, Language};
-use nostr::{nips::{nip06::FromMnemonic, nip47::NostrWalletConnectURI}, Filter, Keys, Kind, PublicKey, ToBech32};
+use nostr::{nips::nip47::NostrWalletConnectURI, Filter, Keys, Kind, PublicKey};
 use nostr_sdk::{Client, SubscribeAutoCloseOptions};
 use std::str::FromStr;
 
@@ -317,33 +314,7 @@ pub fn draw_login_view(
                 ui.add(egui::TextEdit::singleline(&mut app_data.secret_key_input)
                     .password(true)
                     .hint_text(secret_key_hint_text));
-                if ui.button("ニーモニックから新しいキーを生成").clicked() {
-                    // Generate a new mnemonic
-                    let mut entropy = [0u8; 16]; // 128 bits of entropy for a 12-word mnemonic
-                    rand::thread_rng().fill_bytes(&mut entropy);
-                    if let Ok(mnemonic) = Mnemonic::from_entropy_in(Language::English, &entropy) {
-                        let phrase = mnemonic.to_string();
-                        app_data.generated_mnemonic = Some(phrase.clone());
-
-                        // Derive keys from mnemonic
-                        if let Ok(keys) = Keys::from_mnemonic(&phrase, None) {
-                            // Based on compiler errors, `secret_key()` returns a reference directly.
-                            let sk_ref = keys.secret_key();
-                            let nsec = sk_ref.to_bech32().unwrap(); // Infallible error, so unwrap is safe.
-                            app_data.secret_key_input = nsec;
-                        }
-                    }
-                }
             });
-
-            if let Some(mnemonic) = &app_data.generated_mnemonic {
-                ui.add_space(10.0);
-                ui.label("生成されたニーモニックフレーズ：");
-                ui.label("この12個の単語を安全な場所に保管してください。これはあなたの鍵を復元する唯一の方法です。");
-
-                ui.add(egui::Label::new(egui::RichText::new(mnemonic).monospace()).wrap());
-                ui.add_space(10.0);
-            }
 
             ui.horizontal(|ui| {
                 ui.label(passphrase_label_text);


### PR DESCRIPTION
あなたの要件変更に基づき、アプリケーションからNIP-06に関連するすべての機能を削除しました。

具体的には、新規登録画面にあった「ニーモニックから新しいキーを生成」ボタンと、それに関連するロジックおよびUIを削除しました。

これにより、新規登録は既存の秘密鍵（nsec）を直接入力する方法のみに限定されます。