### PR TITLE
This change updates the creation of NIP-57 zap requests (kind 9734) t…

### DIFF
--- a/src/nostr_client.rs
+++ b/src/nostr_client.rs
@@ -390,6 +390,7 @@ pub async fn fetch_timeline_events(
 
                 timeline_posts.push(TimelinePost {
                     id: event.id,
+                    kind: event.kind,
                     author_pubkey: event.pubkey,
                     author_metadata: profiles.get(&event.pubkey).cloned().unwrap_or_default(),
                     content: event.content.clone(),

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,5 @@
 use eframe::egui;
-use nostr::{nips::nip47::NostrWalletConnectURI, PublicKey, Timestamp, Keys, EventId};
+use nostr::{nips::nip47::NostrWalletConnectURI, PublicKey, Timestamp, Keys, EventId, Kind};
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use chrono::{DateTime, Utc};
@@ -81,6 +81,7 @@ pub enum ImageState {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TimelinePost {
     pub id: EventId,
+    pub kind: Kind,
     pub author_pubkey: PublicKey,
     pub author_metadata: ProfileMetadata,
     pub content: String,

--- a/src/ui/home_view.rs
+++ b/src/ui/home_view.rs
@@ -195,6 +195,7 @@ pub fn draw_home_view(
                                                 &post_to_zap.author_metadata.lud16,
                                                 amount_sats,
                                                 Some(post_to_zap.id),
+                                                Some(post_to_zap.kind),
                                             ).await;
 
                                             let mut data = app_data_clone.lock().unwrap();

--- a/src/ui/zap.rs
+++ b/src/ui/zap.rs
@@ -51,6 +51,7 @@ pub async fn send_zap_request(
     lud16: &str,
     amount_sats: u64,
     note_id: Option<nostr::EventId>,
+    note_kind: Option<Kind>,
 ) -> Result<()> {
     let amount_msats = amount_sats * 1000;
     let lnurl = lud16_to_lnurl(lud16)?;
@@ -84,6 +85,9 @@ pub async fn send_zap_request(
     ];
     if let Some(event_id) = note_id {
         tags.push(Tag::event(event_id));
+    }
+    if let Some(kind) = note_kind {
+        tags.push(Tag::parse(["k", &kind.as_u16().to_string()])?);
     }
     let zap_request = EventBuilder::new(Kind::ZapRequest, "")
         .tags(tags)


### PR DESCRIPTION
…o include the 'k' tag, which specifies the kind of the event being zapped.

To support this, the internal `TimelinePost` data structure was modified to include the event `kind`. The `send_zap_request` function was updated to accept the event kind and add it to the zap request's tags.

This aligns the application's zap implementation more closely with the NIP-57 specification.